### PR TITLE
fix tab formatting in cluster.rb

### DIFF
--- a/lib/quickdraw/cluster.rb
+++ b/lib/quickdraw/cluster.rb
@@ -8,7 +8,7 @@ class Quickdraw::Cluster
 	end
 
 	def self.spawn(n = Etc.nprocessors, &block)
-	  new.tap do |cluster|
+		new.tap do |cluster|
 			n.times { cluster.fork(&block) }
 		end
 	end


### PR DESCRIPTION
2 spaces were used in place of a tab character