### PR TITLE
Add =~ matcher for regexes

### DIFF
--- a/lib/quickdraw/context.rb
+++ b/lib/quickdraw/context.rb
@@ -12,7 +12,8 @@ class Quickdraw::Context
 		Quickdraw::Matchers::ToBeA,
 		Quickdraw::Matchers::ToHaveAttributes,
 		Quickdraw::Matchers::ToRaise,
-		Quickdraw::Matchers::ToReceive
+		Quickdraw::Matchers::ToReceive,
+		Quickdraw::Matchers::PatternMatch
 	].freeze
 
 	class << self

--- a/lib/quickdraw/matchers.rb
+++ b/lib/quickdraw/matchers.rb
@@ -12,4 +12,5 @@ module Quickdraw::Matchers
 	autoload :ToHaveAttributes, "quickdraw/matchers/to_have_attributes"
 	autoload :ToRaise, "quickdraw/matchers/to_raise"
 	autoload :ToReceive, "quickdraw/matchers/to_receive"
+	autoload :PatternMatch, "quickdraw/matchers/pattern_match"
 end

--- a/lib/quickdraw/matchers/pattern_match.rb
+++ b/lib/quickdraw/matchers/pattern_match.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Quickdraw::Matchers::PatternMatch
+	def =~(other)
+		assert value =~ other do
+			"expected `#{value.inspect}` to =~ `#{other.inspect}`"
+		end
+	end
+end

--- a/test/matchers/pattern_match.test.rb
+++ b/test/matchers/pattern_match.test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe "=~" do
+	test "when equal" do
+		expect {
+			test { expect("a") =~ /a/ }
+		}.to_pass
+	end
+
+	test "when not equal" do
+		expect {
+			test { expect("a") =~ /b/ }
+		}.to_fail message: %(expected `"a"` to =~ `"/b/"`)
+	end
+end


### PR DESCRIPTION
I wanted to do some regex matching, but found it wasn't included. This PR adds support for syntax like

```ruby
expect("a") =~ /a/
```

Wasn't sure what to call the class or what `=~` is called in general, but according to chatGPT this matcher is called a "pattern match operator", so I went with that.

> In Ruby, the =~ operator is called the pattern match operator. It is used to match a string against a regular expression. 

