### PR TITLE
Improve startup performance with bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rspec-expectations"
 gem "minitest"
 gem "sus"
 gem "covered"
+
+gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,33 +7,38 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    console (1.23.6)
+    bootsnap (1.18.3)
+      msgpack (~> 1.2)
+    console (1.25.2)
       fiber-annotation
-      fiber-local
+      fiber-local (~> 1.1)
       json
     covered (0.25.1)
       console (~> 1.0)
       msgpack (~> 1.0)
     diff-lcs (1.5.1)
     fiber-annotation (0.2.0)
-    fiber-local (1.0.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (0.1.2)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    minitest (5.22.3)
+    minitest (5.24.0)
     msgpack (1.7.2)
-    parallel (1.24.0)
-    parser (3.3.0.5)
+    parallel (1.25.1)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
-    racc (1.7.3)
+    racc (1.8.0)
     rainbow (3.1.1)
-    regexp_parser (2.9.0)
-    rexml (3.2.6)
-    rspec-expectations (3.13.0)
+    regexp_parser (2.9.2)
+    rexml (3.3.0)
+      strscan
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.63.0)
+    rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -44,10 +49,11 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    sus (0.24.6)
+    strscan (3.1.0)
+    sus (0.25.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -55,6 +61,7 @@ PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
+  bootsnap
   covered
   minitest
   quickdraw!

--- a/exe/qt
+++ b/exe/qt
@@ -1,6 +1,19 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "bootsnap"
+
+Bootsnap.setup(
+	cache_dir: "tmp/cache", # Path to your cache
+	ignore_directories: ["node_modules"], # Directory names to skip
+	development_mode: true,
+	load_path_cache: true, # Optimize the LOAD_PATH with a cache
+	compile_cache_iseq: true, # Compile Ruby code into ISeq cache, breaks coverage reporting
+	compile_cache_yaml: true, # Compile YAML into a cache
+	compile_cache_json: true, # Compile JSON into a cache
+	readonly: false, # Use the caches but don't update them on miss or stale entries
+)
+
 module Quickdraw
 	start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
 


### PR DESCRIPTION
On my Mac, this seems to bring the total test time for the Quickdraw tests down from ~40ms to ~30ms.