### PR TITLE
Implement `subject` in `Quickdraw::RSpec`

### DIFF
--- a/lib/quickdraw/rspec.rb
+++ b/lib/quickdraw/rspec.rb
@@ -22,6 +22,11 @@ module Quickdraw::RSpec
 	def context(...) = describe(...)
 	def it(...) = test(...)
 
+	def subject(name = nil, &)
+		let("subject", &)
+		let(name, &) if name
+	end
+
 	def let(name, &block)
 		instance_variable = :"@#{name}"
 

--- a/test/rspec.test.rb
+++ b/test/rspec.test.rb
@@ -16,4 +16,24 @@ RSpec.describe Quickdraw::RSpec do
 			end
 		end
 	end
+
+	describe "unnamed subject" do
+		subject { "subj" }
+
+		it "works when referenced as 'subject'" do
+			expect(subject) == "subj"
+		end
+	end
+
+	describe "named subject" do
+		subject(:named_subject) { "subj" }
+
+		it "works when referenced as 'subject'" do
+			expect(subject) == "subj"
+		end
+
+		it "works when referenced by its name" do
+			expect(named_subject) == "subj"
+		end
+	end
 end


### PR DESCRIPTION
Both unnamed and named subject are implemented.

Fixes #29