### PR TITLE
Fix CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,8 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
+  arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   covered

--- a/lib/quickdraw/context.rb
+++ b/lib/quickdraw/context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 class Quickdraw::Context
 	class << self
 		def test(name = nil, skip: false, &block)

--- a/test/matchers/to_have_attributes.test.rb
+++ b/test/matchers/to_have_attributes.test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-User = Data.define(:name)
+User = Struct.new(:name, keyword_init: true)
 
 test "success" do
 	expect {


### PR DESCRIPTION
CI's ubuntu-latest is running on an x86_64-linux platform. Since Gemfile.lock is committed, it needs to include this platform for CI to bundle successfully. [Currently](https://github.com/joeldrapper/quickdraw/actions/runs/9751885920/job/26914349515) we get this error:

> Your bundle only supports platforms ["arm64-darwin-22", "arm64-darwin-23"] but your local platform is x86_64-linux. Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again.

Also (if CI is green), you can add branch restrictions now.