### PR TITLE
Gemfile: fix duplicate minitest addition warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "minitest"
 if RUBY_ENGINE == "ruby"
 	group :development do
 		gem "rubocop"
-		gem "minitest"
 		gem "sus"
 		gem "covered"
 	end


### PR DESCRIPTION
When I bundle installed in Quickdraw I got this warning from Bundler:

```
Your Gemfile lists the gem minitest (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```

So I'm guessing we only want the newest minitest declaration for the new RSpec/minitest adapters.