### PR TITLE
Fix nested anonymous block parameter passing

### DIFF
--- a/lib/quickdraw/concurrent_array.rb
+++ b/lib/quickdraw/concurrent_array.rb
@@ -10,8 +10,8 @@ class Quickdraw::ConcurrentArray
 		@monitor.synchronize { @array << value }
 	end
 
-	def each(&)
-		@monitor.synchronize { @array.each(&) }
+	def each(&block)
+		@monitor.synchronize { @array.each(&block) }
 	end
 
 	def concat(other)

--- a/lib/quickdraw/rspec_adapter.rb
+++ b/lib/quickdraw/rspec_adapter.rb
@@ -20,7 +20,7 @@ module Quickdraw::RSpecAdapter
 	end
 
 	module ClassMethods
-		def describe(description, &)
+		def describe(description, &block)
 			Class.new(self) do
 				if respond_to?(:set_temporary_name)
 					case description
@@ -30,7 +30,7 @@ module Quickdraw::RSpecAdapter
 						set_temporary_name description.to_s
 					end
 				end
-				class_exec(&)
+				class_exec(&block)
 			end
 		end
 


### PR DESCRIPTION
When I tried to `bundle exec qt` for Quickdraw's tests, on the `.ruby-version` Ruby 3.3.0, I saw two SyntaxErrors:

```
lib/quickdraw/concurrent_array.rb:14: anonymous block parameter is also used within block (SyntaxError)
lib/quickdraw/rspec_adapter.rb:33: anonymous block parameter is also used within block (SyntaxError)
```

It looks like we can't forward on the anonymous block parameter into nested blocks.

With these fixes the tests ran and passed for me.