### PR TITLE
Fallback to `diff_strings` when `assert_equal_*` has no syntactic changes

### DIFF
--- a/lib/quickdraw/assertions.rb
+++ b/lib/quickdraw/assertions.rb
@@ -23,6 +23,7 @@ module Quickdraw::Assertions
 
 		assert(actual == expected) do
 			diff = DIFFER.diff_sql(actual, expected)
+			diff = DIFFER.diff_strings(actual, expected) if no_syntactic_changes?(diff)
 
 			"Expected SQL strings to be equal (compared with `actual == expected`):\n\n#{diff}"
 		end
@@ -35,6 +36,7 @@ module Quickdraw::Assertions
 
 		assert(actual == expected) do
 			diff = DIFFER.diff_html(actual, expected)
+			diff = DIFFER.diff_strings(actual, expected) if no_syntactic_changes?(diff)
 
 			"Expected HTML strings to be equal (compared with `actual == expected`):\n\n#{diff}"
 		end
@@ -47,6 +49,7 @@ module Quickdraw::Assertions
 
 		assert(actual == expected) do
 			diff = DIFFER.diff_ruby(actual, expected)
+			diff = DIFFER.diff_strings(actual, expected) if no_syntactic_changes?(diff)
 
 			"Expected Ruby strings to be equal (compared with `actual == expected`):\n\n#{diff}"
 		end
@@ -150,5 +153,15 @@ module Quickdraw::Assertions
 		refute actual.equal?(expected) do
 			"expected #{actual.inspect} not to be the same object as #{expected.inspect}"
 		end
+	end
+
+	private
+
+	def syntactic_changes?(diff)
+		!no_syntactic_changes?(diff)
+	end
+
+	def no_syntactic_changes?(diff)
+		diff.include?("No syntactic changes.")
 	end
 end


### PR DESCRIPTION
When using `assert_equal_ruby` the diff wouldn't show when you have whitespace differences in the strings you are comparing.

This pull request changes that behavior by falling back to `diff_strings` when `assert_equal_*` has no syntactic changes.


**Before**:
![CleanShot 2025-01-28 at 23 06 28@2x](https://github.com/user-attachments/assets/e26bfbcb-a5d4-479e-a008-5b735ef339da)


**After**:

![CleanShot 2025-01-28 at 23 40 59@2x](https://github.com/user-attachments/assets/4eaa8cec-39f0-4098-9029-b64e08800080)
