### PR TITLE
Fix test skip behavior

### DIFF
--- a/lib/quickdraw/test.rb
+++ b/lib/quickdraw/test.rb
@@ -20,7 +20,7 @@ class Quickdraw::Test
 		around_test { instance_exec(&@block) }
 		teardown
 	rescue Exception => error
-		@runner.error!({
+		error!({
 			"location" => @block.source_location,
 			"description" => @description,
 			"message" => error.message,
@@ -56,7 +56,7 @@ class Quickdraw::Test
 	# Indicate that an assertion passed successfully.
 	def success!
 		if @skip
-			@runner.failure! { "The skipped test `#{@description}` started passing." }
+			@runner.failure!("The skipped test `#{@description}` started passing.")
 		else
 			@runner.success!(@description)
 		end
@@ -82,6 +82,16 @@ class Quickdraw::Test
 				"path" => location.path,
 				"line" => location.lineno,
 			})
+		end
+
+		nil
+	end
+
+	def error!(...)
+		if @skip
+			@runner.success!(@description)
+		else
+			@runner.error!(...)
 		end
 
 		nil


### PR DESCRIPTION
When I write tests, I usually set them to skip mode. This is so I don't have to think too hard about how to test things, or even if it's really working. So when I noticed that skip mode doesn't work, I started having a panic attack thinking about all the tests I would have to take off of skip mode.

So instead I decided to open a PR to fix skip mode, so I can go back to my skipping, frolicking, care free life I once lived.