### PR TITLE
stop error backtrace at framework

### DIFF
--- a/lib/quickdraw/cli.rb
+++ b/lib/quickdraw/cli.rb
@@ -24,6 +24,10 @@ class Quickdraw::CLI
 				exit
 			end
 
+			parser.on("-b", "--backtrace", "Backtrace past test into Quickdraw") do |it|
+				self.backtrace = true
+			end
+
 			parser.on("-p N", "--processes N", Integer, "Number of Ruby Processes to fork") do |it|
 				self.processes = it
 			end
@@ -52,6 +56,10 @@ class Quickdraw::CLI
 
 	def parse_files
 		@files = @args[0] || "./**/*.test.rb"
+	end
+
+	def backtrace=(value)
+		@backtrace = value
 	end
 
 	def processes=(value)
@@ -119,6 +127,7 @@ class Quickdraw::CLI
 		require CONFIG_PATH if File.exist?(CONFIG_PATH)
 
 		$quickdraw_runner = Quickdraw::Runner.new(
+			backtrace: @backtrace,
 			processes: @processes || Quickdraw::Config.processes,
 			threads: @threads || Quickdraw::Config.threads,
 			files: Dir.glob(@files),

--- a/lib/quickdraw/runner.rb
+++ b/lib/quickdraw/runner.rb
@@ -11,7 +11,8 @@ class Quickdraw::Runner
 		Stopping = "\x04"
 	end
 
-	def initialize(processes:, threads:, files:, seed:)
+	def initialize(backtrace: false, processes:, threads:, files:, seed:)
+		@backtrace = backtrace
 		@processes = processes
 		@threads = threads
 		@seed = seed
@@ -53,7 +54,9 @@ class Quickdraw::Runner
 				"\e[1m#{(error['description'])}\e[0m",
 				"\e[3munexpected \e[1m#{error['name']}\e[0m",
 				error["message"],
-				*error["backtrace"].map { |it| it.gsub(":in `", " in `") },
+				*error["backtrace"]
+					.take_while { |it| @backtrace || !it.include?('Quickdraw::Runner') }
+					.map { |it| it.gsub(":in `", " in `") },
 			].each_with_index do |line, i|
 				puts "#{'  ' * i}#{line}"
 			end


### PR DESCRIPTION
```
./test/invocation.test.rb:37
  call
    unexpected ArgumentError
      wrong number of arguments (given 1, expected 0)
        ./test/invocation.test.rb:39:in 'block (3 levels) in load_tests'
          /home/pushcx/code/hotcake/lib/hotcake.rb:86:in 'Invocation#call'
            ./test/invocation.test.rb:41:in 'block (2 levels) in Quickdraw::Runner#load_tests'
              /opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/quickdraw-06b3b5f9ae7a/lib/quickdraw/test.rb:20:in 'BasicObject#instance_exec'
                /opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/quickdraw-06b3b5f9ae7a/lib/quickdraw/test.rb:20:in 'block in Quickdraw::Test#run'
                  /opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/quickdraw-06b3b5f9ae7a/lib/quickdraw/test.rb:102:in 'Quickdraw::Test#around_test'
                    /opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/quickdraw-06b3b5f9ae7a/lib/quickdraw/test.rb:20:in 'Quickdraw::Test#run'
                      /opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/quickdraw-06b3b5f9ae7a/lib/quickdraw/runner.rb:147:in 'block (2 levels) in Quickdraw::Runner#work'

Passed: 32 | Failed: 0 | Errors: 1
```

As a Quickdraw user, it is not at all useful to backtrace into the framework. That's just distraction I have to read around. I made it an option because I've managed to eventually get every testing tool to throw an exception eventually.

Maybe it's worth a teensy risk to drop the option and write this something like: `take_while { |it| error["backtrace"].first.include?("Quickdraw::") || !it.include?('Quickdraw::Runner') }` so that full backtrace only prints when the exception originates in Quickdraw.

I originally opened this code to fix the apparent bug with the increasing indentation, but it looks like that's an intentional style choice that I just strongly disagree with.

(Speaking of which, this is the first time I have seen Ruby indented with tabs. I feel like offering a feature PR permits one small piece of bikeshedding. Or more productively: I have gotten a lot of peace of mind by using standardrb, disabling `Lint/UselessAssignment` (breaks things mid-refactor) and never thinking about style.)