### PR TITLE
fix increasing indent on error tracebacks

### DIFF
--- a/lib/quickdraw/runner.rb
+++ b/lib/quickdraw/runner.rb
@@ -49,17 +49,14 @@ class Quickdraw::Runner
 		@errors.each do |error|
 			puts
 
-			[
-				"\e[4m#{error['location'][0]}:#{error['location'][1]}\e[0m",
-				"\e[1m#{(error['description'])}\e[0m",
-				"\e[3munexpected \e[1m#{error['name']}\e[0m",
-				error["message"],
-				*error["backtrace"]
-					.take_while { |it| @backtrace || !it.include?('Quickdraw::Runner') }
-					.map { |it| it.gsub(":in `", " in `") },
-			].each_with_index do |line, i|
-				puts "#{'  ' * i}#{line}"
-			end
+			puts "\e[4m#{error['location'][0]}:#{error['location'][1]} #{error['description']}\e[0m"
+			puts "\e[3m  unexpected \e[1m#{error['name']}: #{error['message']}\e[0m"
+			error["backtrace"]
+				.take_while { |it| @backtrace || !it.include?("Quickdraw::Runner") }
+				.map { |it| it.gsub(":in `", " in `") }
+				.each do |line|
+					puts line
+				end
 		end
 
 		@failures.each do |failure|


### PR DESCRIPTION
@joeldrapper and I discussed the increasing error indent I mentioned in #59 and he said it wasn't a desired style. Here's the update:

```
./test/invocation.test.rb:37 call
  unexpected ArgumentError, wrong number of arguments (given 1, expected 0)
  ./test/invocation.test.rb:37:in 'block (3 levels) in load_tests'
  /home/pushcx/code/hotcake/lib/hotcake.rb:86:in 'Invocation#call'

Passed: 32 | Failed: 0 | Errors: 1
```