### PR TITLE
cli: fix running multiple test files

### DIFF
--- a/lib/quickdraw/cli.rb
+++ b/lib/quickdraw/cli.rb
@@ -55,7 +55,7 @@ class Quickdraw::CLI
 	end
 
 	def parse_files
-		@files = @args[0] || "./**/*.test.rb"
+		@files = @args || "./**/*.test.rb"
 	end
 
 	def backtrace=(value)


### PR DESCRIPTION
Running `be qt test/1.test.rb test/2.test.rb` silently ignored all files after the first one. `Dir.glob` accepts an array, so this is an easy fix.

I dislike the temporal coupling of `parse_options` and `parse_args` caused by `OptionParser` mutating its inputs, but I saw it as a separate issue.