### PR TITLE
Improve message from `refute` on failure

### DIFF
--- a/lib/quickdraw/test.rb
+++ b/lib/quickdraw/test.rb
@@ -49,8 +49,16 @@ class Quickdraw::Test
 		nil
 	end
 
-	def refute(value, ...)
-		assert(!value, ...)
+	def refute(value)
+		if !value
+			success!
+		elsif block_given?
+			failure! { yield(value) }
+		else
+			failure! { "expected #{value.inspect} to be falsy" }
+		end
+
+		nil
 	end
 
 	# Indicate that an assertion passed successfully.

--- a/test/quickdraw.test.rb
+++ b/test/quickdraw.test.rb
@@ -15,3 +15,17 @@ end
 test "refute", skip: true do
 	refute true
 end
+
+test "refute custom message" do
+	runner = assert_test(failures: 1) do
+		refute(32) { |val| "#{val} not falsy" }
+	end
+	assert_equal runner.failures.last["message"], "32 not falsy"
+end
+
+test "refute default message" do
+	runner = assert_test(failures: 1) do
+		refute 32
+	end
+	assert_equal runner.failures.last["message"], "expected 32 to be falsy"
+end


### PR DESCRIPTION
The previous implementation was to `assert(!value)` which led to confusing failure messages when using `refute` directly.

For custom failure messages, `!value` is always `false` on failure, so `false` was passed to the custom message block where the caller might instead expect the value that caused the failure.

Similarly, the default failure message was always "expected false to be truthy" when really the expectation is that something truthy is falsy.